### PR TITLE
Const-correctness on LoadMovie

### DIFF
--- a/src/VCR/VCR.cpp
+++ b/src/VCR/VCR.cpp
@@ -66,7 +66,7 @@ void VCR_SetErrorCallback(MsgFunc callb)
 /// Its used in start, restart and start recording, so its handy to have it as a helper function.
 /// </summary>
 /// <param name="path"> path to .m64 to find the st</param>
-static void PrepareCore(char* path)
+static void PrepareCore(const char* path)
 {
 	if (gMovieHeader->startFlags == MOVIE_START_FROM_NOTHING)
 	{
@@ -271,7 +271,7 @@ int VCR_LoadMovieData(uint32_t* buf, unsigned len)
 	return VCR_ST_SUCCESS;
 }
 
-m64p_error VCR_StartMovie(char* path)
+m64p_error VCR_StartMovie(const char* path)
 {
 	//@TODO maybe switch to custom errors
 	if (VCR_IsPlaying()) return M64ERR_INTERNAL;
@@ -383,4 +383,3 @@ m64p_error VCR_StartRecording(char* path, char* author, char* desc, int startTyp
 //else no play
 //
 //========== Build: 0 succeeded, 1 failed, 0 skipped ==========
-

--- a/src/VCR/VCR.cpp
+++ b/src/VCR/VCR.cpp
@@ -187,10 +187,6 @@ BOOL VCR_GetKeys(BUTTONS* keys, unsigned channel)
 		}
 		keys->Value = (*gMovieBuffer)[curSample++].Value; //get the value, then advance frame
 	}
-	if (curSample == 200)
-	{
-		main_state_load("loadthis.st");
-	}
 	return false;
 }
 

--- a/src/api/api_export.ver
+++ b/src/api/api_export.ver
@@ -90,4 +90,5 @@ VCR_IsReadOnly;
 VCR_SetReadOnly;
 VCR_StartRecording;
 VCR_StartMovie;
+VCR_LoadErrorStates;
 local: *; };

--- a/src/api/m64p_vcr.h
+++ b/src/api/m64p_vcr.h
@@ -147,8 +147,8 @@ EXPORT m64p_error CALL VCR_StartRecording(char* path, char* author, char* desc, 
 /// </summary>
 /// <param name="path">- path/to/movie.m64</param>
 /// <returns>M64ERR_FILES - .m64 or .st not found, M64ERR_NO_MEMORY - out of memory, M64ERR_INTERNAL - buffer already exists, otherwise M64ERR_SUCCESS</returns>
-typedef m64p_error (*ptr_VCR_StartMovie)(char* path);
-EXPORT m64p_error CALL VCR_StartMovie(char* path);
+typedef m64p_error (*ptr_VCR_StartMovie)(const char* path);
+EXPORT m64p_error CALL VCR_StartMovie(const char* path);
 
 #ifdef __cplusplus
 }

--- a/src/api/m64p_vcr.h
+++ b/src/api/m64p_vcr.h
@@ -119,7 +119,7 @@ EXPORT BOOL CALL VCR_IsPlaying();
 /// </summary>
 /// <see cref="VCR_IsReadOnly"/>
 /// <returns>true or false</returns>
-typedef BOOL (*ptr_IsReadOnly)(void);
+typedef BOOL (*ptr_VCR_IsReadOnly)(void);
 EXPORT BOOL CALL VCR_IsReadOnly();
 
 

--- a/src/backends/plugins_compat/input_plugin_compat.c
+++ b/src/backends/plugins_compat/input_plugin_compat.c
@@ -164,10 +164,6 @@ static m64p_error input_plugin_get_input(void* opaque, uint32_t* input_, int is_
     {
         VCR_SetKeys(keys, cin_compat->control_id);
     }
-    if (VCR_IsPlaying() && !is_test)
-    {
-        displaykeys(keys);
-    }
 #endif
     return M64ERR_SUCCESS;
 }


### PR DESCRIPTION
Because the `char*` is not being modified, it should be `const char*`.

Besides being more correct, it also enables the user to directly pass the value of `string::c_str()` into `LoadMovie` without doing anything unsafe.